### PR TITLE
Mod verification & space colony fixes & destroy defeated factions

### DIFF
--- a/Source/RimWar/Harmony/HarmonyPatches.cs
+++ b/Source/RimWar/Harmony/HarmonyPatches.cs
@@ -29,12 +29,26 @@ namespace RimWar.Harmony
     [StaticConstructorOnStartup]
     public class RimWarMod : Mod
     {
+        private readonly string ModId = "rimworld.torann.rimwar";
         public static int RimpointsPerGift = 90;
         private static readonly Type patchType = typeof(RimWarMod);
 
+        private HarmonyLib.Harmony harmonyInstance;
+
+        private void PatchHarmonyMethod(Type rimworldMethodType,
+                                        string rimworldMethodName,
+                                        Type[] prms = null,
+                                        HarmonyMethod prefixMethod = null,
+                                        HarmonyMethod postfixMethod = null,
+                                        HarmonyMethod transpilerMethod = null)
+        {
+            harmonyInstance.Patch(AccessTools.Method(rimworldMethodType, rimworldMethodName, prms, null),
+                                  prefix: prefixMethod, postfix: postfixMethod, transpiler: transpilerMethod);
+        }
+
         public RimWarMod(ModContentPack content) : base(content)
         {
-            HarmonyLib.Harmony harmonyInstance = new HarmonyLib.Harmony("rimworld.torann.rimwar");
+            harmonyInstance = new HarmonyLib.Harmony(ModId);
             //Postfix
             //1.3 //
             //harmonyInstance.Patch(AccessTools.Method(typeof(TransportPodsArrivalAction_Shuttle), "Arrived", new Type[]
@@ -42,50 +56,108 @@ namespace RimWar.Harmony
             //                    typeof(List<ActiveDropPodInfo>),
             //                    typeof(int)
             //    }, null), null, new HarmonyMethod(patchType, "ShuttleArrived_SettlementHasAttackers_Postfix", null), null);
-            harmonyInstance.Patch(AccessTools.Method(typeof(TransportersArrivalAction_AttackSettlement), "Arrived", new Type[]
-                {
-                                typeof(List<ActiveTransporterInfo>),
-                                typeof(PlanetTile)
-                }, null), null, new HarmonyMethod(patchType, "PodsArrived_SettlementHasAttackers_Postfix", null), null);
-            harmonyInstance.Patch(AccessTools.Method(typeof(RimWorld.Planet.SettlementUtility), "AttackNow", new Type[]
-                {
-                    typeof(Caravan),
-                    typeof(RimWorld.Planet.Settlement)
-                }, null), null, new HarmonyMethod(patchType, "AttackNow_SettlementReinforcement_Postfix", null), null);
-            harmonyInstance.Patch(AccessTools.Method(typeof(Settlement), "GetInspectString", new Type[]
-                {
-                }, null), null, new HarmonyMethod(patchType, "Settlement_InspectString_WithPoints_Postfix", null), null);
-            harmonyInstance.Patch(AccessTools.Method(typeof(Caravan_PathFollower), "StartPath", new Type[]
-                {
-                    typeof(PlanetTile),
-                    typeof(CaravanArrivalAction),
-                    typeof(bool),
-                    typeof(bool)
-                }, null), null, new HarmonyMethod(patchType, "Pather_StartPath_WarObjects", null), null);
+
+            PatchHarmonyMethod(typeof(TransportersArrivalAction_AttackSettlement),
+                                "Arrived",
+                                new Type[]{ typeof(List<ActiveTransporterInfo>),
+                                            typeof(PlanetTile) },
+                                postfixMethod: new HarmonyMethod(patchType, nameof(PodsArrived_SettlementHasAttackers_Postfix)));
+            PatchHarmonyMethod(typeof(RimWorld.Planet.SettlementUtility),
+                                "AttackNow",
+                                new Type[]{ typeof(Caravan),
+                                            typeof(RimWorld.Planet.Settlement) },
+                                postfixMethod: new HarmonyMethod(patchType, nameof(AttackNow_SettlementReinforcement_Postfix)));
+            PatchHarmonyMethod(typeof(Settlement),
+                                "GetInspectString",
+                                postfixMethod: new HarmonyMethod(patchType, nameof(Settlement_InspectString_WithPoints_Postfix)));
+            PatchHarmonyMethod(typeof(Caravan_PathFollower), "StartPath",
+                                new Type[]{ typeof(PlanetTile),
+                                            typeof(CaravanArrivalAction),
+                                            typeof(bool),
+                                            typeof(bool) },
+                                postfixMethod: new HarmonyMethod(patchType, nameof(Pather_StartPath_WarObjects_Postfix)));
+            PatchHarmonyMethod(typeof(WorldSelectionDrawer), "DrawSelectionOverlays",
+                                postfixMethod: new HarmonyMethod(patchType, nameof(WorldCapitolOverlay)));
+            PatchHarmonyMethod(typeof(CaravanEnterMapUtility), "Enter",
+                                new Type[]{ typeof(Caravan), typeof(Map),
+                                            typeof(Func<Pawn, IntVec3>),
+                                            typeof(CaravanDropInventoryMode),
+                                            typeof(bool) },
+                                postfixMethod: new HarmonyMethod(patchType, nameof(AttackInjuredSettlement_Postfix)));
+            PatchHarmonyMethod(typeof(Settlement), "GetShuttleFloatMenuOptions",
+                                new Type[]{ typeof(IEnumerable<IThingHolder>),
+                                            typeof(Action<PlanetTile, TransportersArrivalAction>) },
+                                postfixMethod: new HarmonyMethod(patchType, nameof(Settlement_ShuttleReinforce_Postfix)));
+            PatchHarmonyMethod(typeof(ThingSetMaker), "Generate",
+                                new Type[]{ typeof(ThingSetMakerParams) },
+                                postfixMethod: new HarmonyMethod(patchType, nameof(ThingSetMaker_TraderCheck_Postfix)));
+            PatchHarmonyMethod(typeof(FactionGiftUtility), "GiveGift",
+                                new Type[]{ typeof(List<ActiveTransporterInfo>),
+                                            typeof(Settlement) },
+                                prefixMethod: new HarmonyMethod(patchType, nameof(GivePodGiftAsRimWarPoints_Prefix)));
+            PatchHarmonyMethod(typeof(FactionGiftUtility), "GiveGift",
+                                new Type[]{ typeof(List<Tradeable>),
+                                            typeof(Faction),
+                                            typeof(GlobalTargetInfo) },
+                                prefixMethod: new HarmonyMethod(patchType, nameof(GiveGiftAsRimWarPoints_Prefix)));
+            PatchHarmonyMethod(typeof(IncidentWorker), "TryExecute",
+                                new Type[]{ typeof(IncidentParms) },
+                                prefixMethod: new HarmonyMethod(patchType, nameof(IncidentWorker_Prefix)));
+            PatchHarmonyMethod(typeof(IncidentWorker_CaravanDemand), "ActionGive",
+                                new Type[]{ typeof(Caravan),
+                                            typeof(List<ThingCount>),
+                                            typeof(List<Pawn>) },
+                                prefixMethod: new HarmonyMethod(patchType, nameof(Caravan_Give_Prefix)));
+            PatchHarmonyMethod(typeof(IncidentWorker_NeutralGroup), "TryResolveParms",
+                                new Type[]{ typeof(IncidentParms) },
+                                prefixMethod: new HarmonyMethod(patchType, nameof(TryResolveParms_Points_Prefix)));
+            PatchHarmonyMethod(typeof(CaravanExitMapUtility), "ExitMapAndCreateCaravan",
+                                new Type[]{ typeof(IEnumerable<Pawn>),
+                                            typeof(Faction),
+                                            typeof(PlanetTile),
+                                            typeof(PlanetTile),
+                                            typeof(PlanetTile),
+                                            typeof(bool) },
+                                prefixMethod: new HarmonyMethod(patchType, nameof(ExitMapPostBattle_Prefix)));
+            PatchHarmonyMethod(typeof(IncidentQueue), "Add",
+                                new Type[]{ typeof(IncidentDef),
+                                            typeof(int),
+                                            typeof(IncidentParms),
+                                            typeof(int) },
+                                prefixMethod: new HarmonyMethod(patchType, nameof(IncidentQueueAdd_Replacement_Prefix)));
+            PatchHarmonyMethod(typeof(FactionDialogMaker), "CallForAid",
+                                new Type[]{ typeof(Map), typeof(Faction) },
+                                prefixMethod: new HarmonyMethod(patchType, nameof(CallForAid_Replacement_Patch)));
+            PatchHarmonyMethod(typeof(SymbolStack), "Push",
+                                new Type[]{ typeof(string),
+                                            typeof(ResolveParams),
+                                            typeof(string) },
+                                prefixMethod: new HarmonyMethod(patchType, nameof(GenStep_Map_Params_Prefix)));
+            PatchHarmonyMethod(typeof(GenStep_Settlement), "ScatterAt",
+                                new Type[]{ typeof(IntVec3),
+                                            typeof(Map),
+                                            typeof(GenStepParams),
+                                            typeof(int) },
+                                prefixMethod: new HarmonyMethod(patchType, nameof(GenStep_Map_ID_Prefix)));
+
+            PatchHarmonyMethod(typeof(WorldPathPool), "GetEmptyWorldPath",
+                                prefixMethod: new HarmonyMethod(patchType, nameof(WorldPathPool_Prefix_Patch)));
+            PatchHarmonyMethod(typeof(IncidentWorker_Ambush_EnemyFaction), "CanFireNowSub",
+                                prefixMethod: new HarmonyMethod(patchType, nameof(CanFireNow_Ambush_EnemyFaction_RemovalPatch_Prefix)));
+            PatchHarmonyMethod(typeof(IncidentWorker_CaravanDemand), "CanFireNowSub",
+                                prefixMethod: new HarmonyMethod(patchType, nameof(CanFireNow_CaravanDemand_RemovalPatch_Prefix)));
+            PatchHarmonyMethod(typeof(IncidentWorker_CaravanMeeting), "CanFireNowSub",
+                                prefixMethod: new HarmonyMethod(patchType, nameof(CanFireNow_CaravanMeeting_RemovalPatch_Prefix)));
+            PatchHarmonyMethod(typeof(IncidentWorker_PawnsArrive), "CanFireNowSub",
+                                prefixMethod: new HarmonyMethod(patchType, nameof(CanFireNow_PawnsArrive_RemovalPatch_Prefix)));
+
+            harmonyInstance.PatchAll();
+
             //harmonyInstance.Patch(AccessTools.Method(typeof(IncidentWorker_CaravanMeeting), "RemoveAllPawnsAndPassToWorld", new Type[]
             //    {
             //        typeof(Caravan)
             //    }, null), null, new HarmonyMethod(patchType, "Caravan_MoveOn_Prefix", null), null);
-            harmonyInstance.Patch(AccessTools.Method(typeof(WorldSelectionDrawer), "DrawSelectionOverlays", new Type[]
-                {
-                }, null), null, new HarmonyMethod(patchType, "WorldCapitolOverlay", null), null);
-            harmonyInstance.Patch(AccessTools.Method(typeof(CaravanEnterMapUtility), "Enter", new Type[]
-                {
-                    typeof(Caravan),
-                    typeof(Map),
-                    typeof(Func<Pawn, IntVec3>),
-                    typeof(CaravanDropInventoryMode),
-                    typeof(bool)
-                }, null), null, new HarmonyMethod(patchType, "AttackInjuredSettlement_Postfix", null), null);
-            harmonyInstance.Patch(AccessTools.Method(typeof(Settlement), "GetShuttleFloatMenuOptions", new Type[]
-                {
-                    typeof(IEnumerable<IThingHolder>),
-                    typeof(Action<PlanetTile, TransportersArrivalAction>)
-                }, null), null, new HarmonyMethod(patchType, "Settlement_ShuttleReinforce_Postfix", null), null);
-            harmonyInstance.Patch(AccessTools.Method(typeof(ThingSetMaker), "Generate", new Type[]
-                {
-                    typeof(ThingSetMakerParams)
-                }, null), null, new HarmonyMethod(patchType, "ThingSetMaker_TraderCheck_Postfix", null), null);
+
             //harmonyInstance.Patch(AccessTools.Method(typeof(PlaySettings), "DoPlaySettingsGlobalControls", new Type[]
             //    {
             //        typeof(WidgetRow),
@@ -100,40 +172,6 @@ namespace RimWar.Harmony
 
             //Prefix
 
-            harmonyInstance.Patch(AccessTools.Method(typeof(FactionGiftUtility), "GiveGift", new Type[]
-                {
-                    typeof(List<ActiveTransporterInfo>),
-                    typeof(Settlement)
-                }, null), new HarmonyMethod(patchType, "GivePodGiftAsRimWarPoints_Prefix", null), null, null);
-            harmonyInstance.Patch(AccessTools.Method(typeof(FactionGiftUtility), "GiveGift", new Type[]
-                {
-                    typeof(List<Tradeable>),
-                    typeof(Faction),
-                    typeof(GlobalTargetInfo)
-                }, null), new HarmonyMethod(patchType, "GiveGiftAsRimWarPoints_Prefix", null), null, null);
-            harmonyInstance.Patch(AccessTools.Method(typeof(IncidentWorker), "TryExecute", new Type[]
-                {
-                    typeof(IncidentParms)
-                }, null), new HarmonyMethod(patchType, "IncidentWorker_Prefix", null), null, null);
-            harmonyInstance.Patch(AccessTools.Method(typeof(IncidentWorker_CaravanDemand), "ActionGive", new Type[]
-                {
-                    typeof(Caravan),
-                    typeof(List<ThingCount>),
-                    typeof(List<Pawn>)
-                }, null), new HarmonyMethod(patchType, "Caravan_Give_Prefix", null), null, null);
-            harmonyInstance.Patch(AccessTools.Method(typeof(IncidentWorker_NeutralGroup), "TryResolveParms", new Type[]
-                {
-                    typeof(IncidentParms)
-                }, null), new HarmonyMethod(patchType, "TryResolveParms_Points_Prefix", null), null, null);
-            harmonyInstance.Patch(AccessTools.Method(typeof(CaravanExitMapUtility), "ExitMapAndCreateCaravan", new Type[]
-                {
-                    typeof(IEnumerable<Pawn>),
-                    typeof(Faction),
-                    typeof(PlanetTile),
-                    typeof(PlanetTile),
-                    typeof(PlanetTile),
-                    typeof(bool)
-                }, null), new HarmonyMethod(patchType, "ExitMapPostBattle_Prefix", null), null, null);
             //Unused
             //harmonyInstance.Patch(AccessTools.Method(typeof(Faction), "TryAffectGoodwillWith", new Type[]
             //    {
@@ -144,45 +182,6 @@ namespace RimWar.Harmony
             //        typeof(HistoryEventDef),
             //        typeof(GlobalTargetInfo?)
             //    }, null), new HarmonyMethod(patchType, "TryAffectGoodwillWith_Reduction_Prefix", null), null, null);
-            harmonyInstance.Patch(AccessTools.Method(typeof(IncidentQueue), "Add", new Type[]
-                {
-                    typeof(IncidentDef),
-                    typeof(int),
-                    typeof(IncidentParms),
-                    typeof(int)
-                }, null), new HarmonyMethod(patchType, "IncidentQueueAdd_Replacement_Prefix", null), null, null);
-            harmonyInstance.Patch(AccessTools.Method(typeof(FactionDialogMaker), "CallForAid", new Type[]
-                {
-                    typeof(Map),
-                    typeof(Faction)
-                }, null), new HarmonyMethod(patchType, "CallForAid_Replacement_Patch", null), null, null);
-            harmonyInstance.Patch(AccessTools.Method(typeof(SymbolStack), "Push", new Type[]
-                {
-                    typeof(string),
-                    typeof(ResolveParams),
-                    typeof(string)
-                }, null), new HarmonyMethod(patchType, "GenStep_Map_Params_Prefix", null), null, null);
-            harmonyInstance.Patch(AccessTools.Method(typeof(GenStep_Settlement), "ScatterAt", new Type[]
-                {
-                    typeof(IntVec3),
-                    typeof(Map),
-                    typeof(GenStepParams),
-                    typeof(int)
-                }, null), new HarmonyMethod(patchType, "GenStep_Map_ID_Prefix", null), null, null);
-
-            harmonyInstance.Patch(AccessTools.Method(typeof(WorldPathPool), "GetEmptyWorldPath"),
-                prefix: new HarmonyMethod(patchType, nameof(WorldPathPool_Prefix_Patch)));
-
-            harmonyInstance.Patch(AccessTools.Method(typeof(IncidentWorker_Ambush_EnemyFaction), "CanFireNowSub"),
-                prefix: new HarmonyMethod(patchType, nameof(CanFireNow_Ambush_EnemyFaction_RemovalPatch_Prefix)));
-            harmonyInstance.Patch(AccessTools.Method(typeof(IncidentWorker_CaravanDemand), "CanFireNowSub"),
-                prefix: new HarmonyMethod(patchType, nameof(CanFireNow_CaravanDemand_RemovalPatch_Prefix)));
-            harmonyInstance.Patch(AccessTools.Method(typeof(IncidentWorker_CaravanMeeting), "CanFireNowSub"),
-                prefix: new HarmonyMethod(patchType, nameof(CanFireNow_CaravanMeeting_RemovalPatch_Prefix)));
-            harmonyInstance.Patch(AccessTools.Method(typeof(IncidentWorker_PawnsArrive), "CanFireNowSub"),
-                prefix: new HarmonyMethod(patchType, nameof(CanFireNow_PawnsArrive_RemovalPatch_Prefix)));
-
-            harmonyInstance.PatchAll();
         }
 
         //public static void WorldSettings_RimWarControls(PlaySettings __instance, ref WidgetRow row, bool worldView)
@@ -641,7 +640,7 @@ namespace RimWar.Harmony
             }
         }
 
-        public static void Pather_StartPath_WarObjects(Caravan_PathFollower __instance, Caravan ___caravan, PlanetTile destTile, CaravanArrivalAction arrivalAction, ref bool __result, bool repathImmediately = false, bool resetPauseStatus = true)
+        public static void Pather_StartPath_WarObjects_Postfix(Caravan_PathFollower __instance, Caravan ___caravan, PlanetTile destTile, CaravanArrivalAction arrivalAction, ref bool __result, bool repathImmediately = false, bool resetPauseStatus = true)
         {
             if (__result == true)
             {

--- a/Source/RimWar/Harmony/HarmonyPatches.cs
+++ b/Source/RimWar/Harmony/HarmonyPatches.cs
@@ -49,19 +49,19 @@ namespace RimWar.Harmony
                 foreach (Patch patch in info.Prefixes)
                 {
                     if (patch.owner != ModId)
-                        Log.Error(string.Format("[RimWar] Possible mod conflict detected: Mod ${0} also patches ${1}.",
+                        Log.Error(string.Format("[RimWar] Possible mod conflict detected: Mod {0} also patches {1}.",
                                                 patch.owner, targetMethod.Name));
                 }
                 foreach (Patch patch in info.Postfixes)
                 {
                     if (patch.owner != ModId)
-                        Log.Error(string.Format("[RimWar] Possible mod conflict detected: Mod ${0} also patches ${1}.",
+                        Log.Error(string.Format("[RimWar] Possible mod conflict detected: Mod {0} also patches {1}.",
                                                 patch.owner, targetMethod.Name));
                 }
                 foreach (Patch patch in info.Transpilers)
                 {
                     if (patch.owner != ModId)
-                        Log.Error(string.Format("[RimWar] Possible mod conflict detected: Mod ${0} also patches ${1}.",
+                        Log.Error(string.Format("[RimWar] Possible mod conflict detected: Mod {0} also patches {1}.",
                                                 patch.owner, targetMethod.Name));
                 }
             }

--- a/Source/RimWar/Harmony/HarmonyPatches.cs
+++ b/Source/RimWar/Harmony/HarmonyPatches.cs
@@ -26,6 +26,7 @@ namespace RimWar.Harmony
 
     //    static HarmonyPatches()
     //    {
+    
     [StaticConstructorOnStartup]
     public class RimWarMod : Mod
     {
@@ -42,8 +43,31 @@ namespace RimWar.Harmony
                                         HarmonyMethod postfixMethod = null,
                                         HarmonyMethod transpilerMethod = null)
         {
-            harmonyInstance.Patch(AccessTools.Method(rimworldMethodType, rimworldMethodName, prms, null),
-                                  prefix: prefixMethod, postfix: postfixMethod, transpiler: transpilerMethod);
+            MethodInfo targetMethod = AccessTools.Method(rimworldMethodType, rimworldMethodName, prms, null);
+            Patches info = HarmonyLib.Harmony.GetPatchInfo(targetMethod);
+            if (info != null) {
+                foreach (Patch patch in info.Prefixes)
+                {
+                    if (patch.owner != ModId)
+                        Log.Error(string.Format("[RimWar] Possible mod conflict detected: Mod ${0} also patches ${1}.",
+                                                patch.owner, targetMethod.Name));
+                }
+                foreach (Patch patch in info.Postfixes)
+                {
+                    if (patch.owner != ModId)
+                        Log.Error(string.Format("[RimWar] Possible mod conflict detected: Mod ${0} also patches ${1}.",
+                                                patch.owner, targetMethod.Name));
+                }
+                foreach (Patch patch in info.Transpilers)
+                {
+                    if (patch.owner != ModId)
+                        Log.Error(string.Format("[RimWar] Possible mod conflict detected: Mod ${0} also patches ${1}.",
+                                                patch.owner, targetMethod.Name));
+                }
+            }
+
+            harmonyInstance.Patch(targetMethod, prefix: prefixMethod, 
+                                  postfix: postfixMethod, transpiler: transpilerMethod);
         }
 
         public RimWarMod(ModContentPack content) : base(content)

--- a/Source/RimWar/Harmony/HarmonyPatches.cs
+++ b/Source/RimWar/Harmony/HarmonyPatches.cs
@@ -50,7 +50,7 @@ namespace RimWar.Harmony
                     foreach (Patch patch in info.Prefixes)
                     {
                         if (patch.owner != ModId)
-                            Log.Error(string.Format("[RimWar] Possible mod conflict detected: Mod {0} also patches {1}.",
+                            Log.Warning(string.Format("[RimWar] Possible mod conflict detected: Mod {0} also patches {1}.",
                                                     patch.owner, targetMethod.Name));
                     }
                 }
@@ -58,7 +58,7 @@ namespace RimWar.Harmony
                     foreach (Patch patch in info.Postfixes)
                     {
                         if (patch.owner != ModId)
-                            Log.Error(string.Format("[RimWar] Possible mod conflict detected: Mod {0} also patches {1}.",
+                            Log.Warning(string.Format("[RimWar] Possible mod conflict detected: Mod {0} also patches {1}.",
                                                     patch.owner, targetMethod.Name));
                     }
                 }
@@ -66,7 +66,7 @@ namespace RimWar.Harmony
                     foreach (Patch patch in info.Transpilers)
                     {
                         if (patch.owner != ModId)
-                            Log.Error(string.Format("[RimWar] Possible mod conflict detected: Mod {0} also patches {1}.",
+                            Log.Warning(string.Format("[RimWar] Possible mod conflict detected: Mod {0} also patches {1}.",
                                                     patch.owner, targetMethod.Name));
                     }
                 }

--- a/Source/RimWar/Harmony/HarmonyPatches.cs
+++ b/Source/RimWar/Harmony/HarmonyPatches.cs
@@ -46,23 +46,29 @@ namespace RimWar.Harmony
             MethodInfo targetMethod = AccessTools.Method(rimworldMethodType, rimworldMethodName, prms, null);
             Patches info = HarmonyLib.Harmony.GetPatchInfo(targetMethod);
             if (info != null) {
-                foreach (Patch patch in info.Prefixes)
-                {
-                    if (patch.owner != ModId)
-                        Log.Error(string.Format("[RimWar] Possible mod conflict detected: Mod {0} also patches {1}.",
-                                                patch.owner, targetMethod.Name));
+                if (prefixMethod != null) {
+                    foreach (Patch patch in info.Prefixes)
+                    {
+                        if (patch.owner != ModId)
+                            Log.Error(string.Format("[RimWar] Possible mod conflict detected: Mod {0} also patches {1}.",
+                                                    patch.owner, targetMethod.Name));
+                    }
                 }
-                foreach (Patch patch in info.Postfixes)
-                {
-                    if (patch.owner != ModId)
-                        Log.Error(string.Format("[RimWar] Possible mod conflict detected: Mod {0} also patches {1}.",
-                                                patch.owner, targetMethod.Name));
+                if (postfixMethod != null) {
+                    foreach (Patch patch in info.Postfixes)
+                    {
+                        if (patch.owner != ModId)
+                            Log.Error(string.Format("[RimWar] Possible mod conflict detected: Mod {0} also patches {1}.",
+                                                    patch.owner, targetMethod.Name));
+                    }
                 }
-                foreach (Patch patch in info.Transpilers)
-                {
-                    if (patch.owner != ModId)
-                        Log.Error(string.Format("[RimWar] Possible mod conflict detected: Mod {0} also patches {1}.",
-                                                patch.owner, targetMethod.Name));
+                if (transpilerMethod != null) {
+                    foreach (Patch patch in info.Transpilers)
+                    {
+                        if (patch.owner != ModId)
+                            Log.Error(string.Format("[RimWar] Possible mod conflict detected: Mod {0} also patches {1}.",
+                                                    patch.owner, targetMethod.Name));
+                    }
                 }
             }
 

--- a/Source/RimWar/Options/Settings.cs
+++ b/Source/RimWar/Options/Settings.cs
@@ -30,7 +30,7 @@ namespace RimWar.Options
         public float objectMovementMultiplier = 1f;
 
         //performance controls
-        public bool threadingEnabled = true;
+        public bool threadingEnabled = false;
         public int averageEventFrequency = 150;        
         public int settlementEventDelay = 50000;
         public int settlementScanDelay = 60000;               
@@ -85,7 +85,7 @@ namespace RimWar.Options
             Scribe_Values.Look<float>(ref this.heatFrequency, "heatFrequency", 2500f, false);
             Scribe_Values.Look<float>(ref this.settlementGrowthRate, "settlementGrowthRate", 1f, false);
             Scribe_Values.Look<bool>(ref this.noPermanentEnemies, "noPermanentEnemies", false, true);
-            Scribe_Values.Look<bool>(ref this.threadingEnabled, "threadingEnabled", true, true);
+            Scribe_Values.Look<bool>(ref this.threadingEnabled, "threadingEnabled", false, true);
             Scribe_Values.Look<bool>(ref this.vassalNotification, "vassalNotification", false, false);
             Scribe_Values.Look<bool>(ref this.alliedNotification, "alliedNotification", false, false);
             Scribe_Values.Look<bool>(ref this.allowDropPodRaids, "allowDropPodRaids", true, true);

--- a/Source/RimWar/Planet/IncidentUtility.cs
+++ b/Source/RimWar/Planet/IncidentUtility.cs
@@ -1208,6 +1208,15 @@ namespace RimWar.Planet
                 defenderResult *= 1.15f;
             }
 
+            if (defender.parent.def.defName == "City_Faction")
+            {
+                defenderResult *= 1.25f;
+            }
+            else if (defender.parent.def.defName == "City_Citadel")
+            {
+                defenderResult *= 1.5f;
+            }
+
             float atkMod = Rand.Range(.5f, .7f);
             float defMod = Rand.Range(.5f, .7f);
 

--- a/Source/RimWar/Planet/WorldComponent_PowerTracker.cs
+++ b/Source/RimWar/Planet/WorldComponent_PowerTracker.cs
@@ -1233,16 +1233,7 @@ namespace RimWar.Planet
             {
                 tmpSettlements = rwsComp.NearbyHostileSettlements;
             }
-            if (rwd.IsAtWar)
-            {
-                RimWorld.Planet.Settlement warSettlement = WorldUtility.GetClosestSettlementInRWDTo(rwd, rwsComp.parent.Tile, Mathf.Min(Mathf.RoundToInt((rwsComp.RimWarPoints * 1.5f) / (settingsRef.settlementScanRangeDivider)), (int)settingsRef.maxSettelementScanRange));
-                if (warSettlement != null)
-                {
-                    tmpSettlements.Add(warSettlement);
-                }
-                targetRange = Mathf.RoundToInt(targetRange * 1.5f);
-            }
-
+            
             if (rwd != null && rwsComp != null)
             {
                 if (tmpSettlements != null && tmpSettlements.Count > 0)
@@ -1254,7 +1245,7 @@ namespace RimWar.Planet
                         {
                             return;
                         }
-                        if (targetTown.Faction == Faction.OfPlayer && rwsComp.PlayerHeat < minimumHeatForPlayerAction && !ignoreRestrictions)
+                        if (targetTown.Faction == Faction.OfPlayer && rwsComp.PlayerHeat < minimumHeatForPlayerAction && !rwd.IsAtWarWith(Faction.OfPlayer) && !ignoreRestrictions)
                         {
                             return;
                         }
@@ -1420,7 +1411,7 @@ namespace RimWar.Planet
                     {
                         return;
                     }
-                    if (targetTown.Faction == Faction.OfPlayer && rwsComp.PlayerHeat < minimumHeatForPlayerAction && !ignoreRestrictions)
+                    if (targetTown.Faction == Faction.OfPlayer && rwsComp.PlayerHeat < minimumHeatForPlayerAction && !rwd.IsAtWarWith(Faction.OfPlayer) && !ignoreRestrictions)
                     {
                         return;
                     }
@@ -1503,15 +1494,6 @@ namespace RimWar.Planet
             {
                 tmpSettlements = rwsComp.NearbyHostileSettlements;
             }
-            if (rwd.IsAtWar)
-            {
-                RimWorld.Planet.Settlement warSettlement = WorldUtility.GetClosestSettlementInRWDTo(rwd, parentSettlement.Tile, Mathf.Min(Mathf.RoundToInt(targetRange), (int)settingsRef.maxSettelementScanRange));
-                if (warSettlement != null)
-                {
-                    tmpSettlements.Add(warSettlement);
-                }
-                targetRange = Mathf.RoundToInt(targetRange * 1.5f);
-            }
 
             if (tmpSettlements != null && tmpSettlements.Count > 0)
             {
@@ -1522,7 +1504,7 @@ namespace RimWar.Planet
                     {
                         return;
                     }
-                    if (targetTown.Faction == Faction.OfPlayer && rwsComp.PlayerHeat < minimumHeatForPlayerAction && !ignoreRestrictions)
+                    if (targetTown.Faction == Faction.OfPlayer && rwsComp.PlayerHeat < minimumHeatForPlayerAction && !rwd.IsAtWarWith(Faction.OfPlayer) && !ignoreRestrictions)
                     {
                         return;
                     }
@@ -1835,7 +1817,7 @@ namespace RimWar.Planet
                     {
                         continue;
                     }
-                    if (wo.Faction == Faction.OfPlayer && rwsComp.PlayerHeat < minimumHeatForPlayerAction && !ignoreRestrictions)
+                    if (wo.Faction == Faction.OfPlayer && rwsComp.PlayerHeat < minimumHeatForPlayerAction && !rwd.IsAtWarWith(Faction.OfPlayer) && !ignoreRestrictions)
                     {
                         continue;
                     }

--- a/Source/RimWar/Planet/WorldComponent_PowerTracker.cs
+++ b/Source/RimWar/Planet/WorldComponent_PowerTracker.cs
@@ -745,7 +745,7 @@ namespace RimWar.Planet
                  *      have pretty check for these factions.
                  *      But need to fix this.
                  */
-                if (factionList[i].IsPlayer || factionList[i] == Faction.OfTradersGuild)
+                if (factionList[i].IsPlayer || factionList[i] == Faction.OfTradersGuild || factionList[i].temporary)
                     continue;
 
                 if (!Find.WorldObjects.AnyFactionSettlementOnRootSurface(factionList[i]))

--- a/Source/RimWar/Planet/WorldComponent_PowerTracker.cs
+++ b/Source/RimWar/Planet/WorldComponent_PowerTracker.cs
@@ -750,6 +750,11 @@ namespace RimWar.Planet
 
                 if (!Find.WorldObjects.AnyFactionSettlementOnRootSurface(factionList[i]))
                 {
+                    // Check for active parties
+                    List<WarObject> wosList = WorldUtility.GetRimWarDataForFaction(factionList[i]).FactionUnits;
+                    if (wosList != null && wosList.Count > 0)
+                        continue;
+
                     if (factionList[i].defeated)
                         continue;
 

--- a/Source/RimWar/Planet/WorldComponent_PowerTracker.cs
+++ b/Source/RimWar/Planet/WorldComponent_PowerTracker.cs
@@ -483,9 +483,9 @@ namespace RimWar.Planet
             return count;
         }
 
-        public void CheckForNewFactions()
+        private void CheckForNewFactions()
         {
-            if(WorldComponent_PowerTracker.CountOnPlanetFactions() > this.RimWarData.Count)
+            if (WorldComponent_PowerTracker.CountOnPlanetFactions() > this.RimWarData.Count)
             {
                 Utility.RimWar_DebugToolsPlanet.ResetFactions(false, true);
             }
@@ -727,8 +727,47 @@ namespace RimWar.Planet
             this.minimumHeatForPlayerAction = Mathf.Clamp(this.minimumHeatForPlayerAction - Rand.RangeInclusive(1, 2), 0, 10000);
         }
 
+        private void CheckFactionDefeated()
+        {
+            /* This shouldn't be needed as Rimworld should mark faction as
+             * defeated by itself, but this does not seem to be a case.
+             * Usually faction can be only defeated by player destroying last
+             * settlement, but this will happen without player intervention.
+             * As such, mark faction as defeated ourselves if not already.
+             */
+            List<Faction> factionList = Find.World.factionManager.AllFactionsVisible.ToList();
+
+            for (int i = 0; i < factionList.Count; i++)
+            {
+                /* TODO Actually check both layers, but traders can be killed only by player currently.
+                 * TODO This will also defeat "Refugee faction" but I find it neat,
+                 *      them coming to player defeated. Sadly RimWorld itself does not
+                 *      have pretty check for these factions.
+                 *      But need to fix this.
+                 */
+                if (factionList[i].IsPlayer || factionList[i] == Faction.OfTradersGuild)
+                    continue;
+
+                if (!Find.WorldObjects.AnyFactionSettlementOnRootSurface(factionList[i]))
+                {
+                    if (factionList[i].defeated)
+                        continue;
+
+                    factionList[i].defeated = true;
+
+                    Find.LetterStack.ReceiveLetter(
+                        // TODO add translation
+                        "Faction destroyed", 
+                        string.Format("All settlements of {0} have been destroyed.", factionList[i].Name), 
+                        LetterDefOf.PositiveEvent
+                    );
+                }
+            }
+        }
+
         public void UpdateFactions()
         {            
+            CheckFactionDefeated();
             IncrementSettlementGrowth();
             ReconstituteSettlements();
             UpdateFactionSettlements(this.RimWarData.RandomElement());

--- a/Source/RimWar/Planet/WorldUtility.cs
+++ b/Source/RimWar/Planet/WorldUtility.cs
@@ -1243,6 +1243,8 @@ namespace RimWar.Planet
                 int distance = 0;
                 for (int i = 0; i < settlements.Count; i++)
                 {
+                    // TODO refactor this call to TraversalDistanceBetween(),
+                    // cost of this is absurd - edge case measured is 4s
                     if (closestSettlement == null)
                     {
                         closestSettlement = settlements[i];
@@ -1255,6 +1257,13 @@ namespace RimWar.Planet
                         {
                             closestSettlement = settlements[i];
                             distance = dist;
+                            /* Cut off. Scanning after some point is from all settlements on map
+                             * is absurd amount of calculation, stop at some arbitrary limit.
+                             * Probably should calculate with party speed setting,
+                             * but whatever, right now just cut calculation.
+                             */
+                            if (distance < 25)
+                                break;
                         }
                     }
                 }

--- a/Source/RimWar/Planet/WorldUtility.cs
+++ b/Source/RimWar/Planet/WorldUtility.cs
@@ -21,7 +21,7 @@ namespace RimWar.Planet
         private static WorldComponent_PowerTracker wcpt = null;
 
         // Do not scan literally everything, put some arbitrary limit
-        private const int maxObjectsPerScan = 20;
+        private const int maxObjectsPerScan = 10;
 
         public static WorldComponent_PowerTracker Get_WCPT()
         {

--- a/Source/RimWar/Planet/WorldUtility.cs
+++ b/Source/RimWar/Planet/WorldUtility.cs
@@ -1381,6 +1381,13 @@ namespace RimWar.Planet
         {
             List<WorldObject> tmpObjects = null;
             //List<WorldObject> tmpObjects = Find.WorldObjects.AllWorldObjects;
+
+            if (from.Layer == Find.WorldGrid.Orbit)
+            {
+                Log.WarningOnce("Attempting to GetWorldObjectsInRange while in space", 664799);
+                return null;
+            }
+
             if (WorldObjectsHolder == null)
                 CopyData();
             lock (locker)

--- a/Source/RimWar/Planet/WorldUtility.cs
+++ b/Source/RimWar/Planet/WorldUtility.cs
@@ -21,7 +21,7 @@ namespace RimWar.Planet
         private static WorldComponent_PowerTracker wcpt = null;
 
         // Do not scan literally everything, put some arbitrary limit
-        private const int maxObjectsPerScan = 5;
+        private const int maxObjectsPerScan = 20;
 
         public static WorldComponent_PowerTracker Get_WCPT()
         {

--- a/Source/RimWar/Utility/Alert_NearbyRimWarObject.cs
+++ b/Source/RimWar/Utility/Alert_NearbyRimWarObject.cs
@@ -32,8 +32,14 @@ namespace RimWar.Utility
                 woGTIList.Clear();
                 RimWar.Options.SettingsRef settingsRef = new Options.SettingsRef();
                 if (settingsRef.alertRange > 0)
-                {                    
-                    foreach (WorldObject wo in WorldUtility.GetWorldObjectsInRange(Find.AnyPlayerHomeMap.Tile, settingsRef.alertRange))
+                {
+                    Map playerMap = Find.AnyPlayerHomeMap;
+                    if (playerMap.Tile.Layer == Find.WorldGrid.Orbit)
+                    {
+                        return null;
+                    }
+
+                    foreach (WorldObject wo in WorldUtility.GetWorldObjectsInRange(playerMap.Tile, settingsRef.alertRange))
                     {
                         if (wo != null && wo.Faction != Faction.OfPlayer)
                         {

--- a/Source/RimWar/Utility/Alert_NearbyRimWarObject.cs
+++ b/Source/RimWar/Utility/Alert_NearbyRimWarObject.cs
@@ -8,12 +8,15 @@ using System.Linq;
 using Verse;
 using RimWar.Planet;
 using UnityEngine;
+using Verse.Noise;
 
 namespace RimWar.Utility
 {
     public class Alert_NearbyRimWarObject : Alert
     {
         private List<GlobalTargetInfo> woGTIList = new List<GlobalTargetInfo>();
+        private int updateRate = 0;
+        private static readonly int refreshRate = 60;
         private List<GlobalTargetInfo> WOGTIList
         {
             get
@@ -28,32 +31,38 @@ namespace RimWar.Utility
         {
             get
             {
-                woNearbyResult.Clear();
-                woGTIList.Clear();
-                RimWar.Options.SettingsRef settingsRef = new Options.SettingsRef();
-                if (settingsRef.alertRange > 0)
-                {
-                    Map playerMap = Find.AnyPlayerHomeMap;
-                    if (playerMap.Tile.Layer == Find.WorldGrid.Orbit)
-                    {
-                        return null;
-                    }
+                if (updateRate >= refreshRate) {
+                    updateRate = 0;
 
-                    foreach (WorldObject wo in WorldUtility.GetWorldObjectsInRange(playerMap.Tile, settingsRef.alertRange))
+                    woNearbyResult.Clear();
+                    woGTIList.Clear();
+                    RimWar.Options.SettingsRef settingsRef = new Options.SettingsRef();
+                    if (settingsRef.alertRange > 0)
                     {
-                        if (wo != null && wo.Faction != Faction.OfPlayer)
+                        Map playerMap = Find.AnyPlayerHomeMap;
+                        if (playerMap.Tile.Layer == Find.WorldGrid.Orbit)
                         {
-                            List<WarObject> tmpList = WorldUtility.GetRimWarObjectsAt(wo.Tile);
-                            if (tmpList != null && tmpList.Count > 0)
+                            return null;
+                        }
+
+                        foreach (WorldObject wo in WorldUtility.GetWorldObjectsInRange(playerMap.Tile, settingsRef.alertRange))
+                        {
+                            if (wo != null && wo.Faction != Faction.OfPlayer)
                             {
-                                foreach (WarObject warObj in tmpList)
+                                List<WarObject> tmpList = WorldUtility.GetRimWarObjectsAt(wo.Tile);
+                                if (tmpList != null && tmpList.Count > 0)
                                 {
-                                    woNearbyResult.Add(warObj);
+                                    foreach (WarObject warObj in tmpList)
+                                    {
+                                        woNearbyResult.Add(warObj);
+                                    }
+                                    woGTIList.Add(wo);
                                 }
-                                woGTIList.Add(wo);
                             }
                         }
-                    }                    
+                    }
+                } else {
+                    updateRate++;
                 }
 
                 List<WarObject> orderedList = woNearbyResult.OrderBy(name => name.Name).ToList();


### PR DESCRIPTION
- Fix issues with scanning for paths in space
- Revert some changes and do optimization
- Defeat factions without settlements and parties. This just sets flag to mark faction as defeated, as this could have only been done by player when destroying last settlement. Defeated factions are marked and do not generate quests nor quest raids.
- Add detection for incompatible mods. There has been lot of bitching 'I have incompatible mods and RimWar breaks'. We ain't fixing that, just add big error so people can't complain.